### PR TITLE
update BUILD_COMMIT env var to point to 'v1.0.1' tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
     # directory containing the project source
     - REPO_DIR=brotli
     # Commit from your-project that you want to build
-    - BUILD_COMMIT=v0.6.0
+    - BUILD_COMMIT=v1.0.1
     # pip dependencies to _build_ project
     - BUILD_DEPENDS=
     # pip dependencies to _test_ project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C %APPVEYOR_BUILD_FOLDER%\\multibuild\\ci\\appveyor\\windows_sdk.cmd"
     REPO_DIR: brotli
-    BUILD_COMMIT: v0.6.0
+    BUILD_COMMIT: v1.0.1
 
   matrix:
 


### PR DESCRIPTION
Simply updating the git submodule as @eustas did with #3 is not enough to trigger our multibuild setup to build from the new commit.
You can see that Travis and Appveyor are still building the previous "v0.6.0" tagged commit:

https://travis-ci.org/google/brotli-wheels/jobs/279488585#L484

Also, note the generated wheels have version 0.6.0 in their file names.
https://ci.appveyor.com/project/szabadka/brotli-wheels/build/1.0.0%238/job/e936y05pib1k768o/artifacts

In order to have multibuild run the build from a specific commit, you have to point to that commit with the `BUILD_COMMIT` environment variable.
The current commit of the git submodule does not make any difference actually, since the BUILD_COMMIT is always checked out before a build, so next time it's sufficient to just change the latter.