### PR TITLE
script to download wheels from github and upload to pypi

### DIFF
--- a/push_pypi_release.sh
+++ b/push_pypi_release.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+rm -rf dist || true
+mkdir -p dist
+curl -s https://api.github.com/repos/anthrotype/brotli-wheels/releases/latest | jq -r '.assets[].browser_download_url' | xargs wget -P dist/ -nv
+twine upload dist/*


### PR DESCRIPTION
This is the shell script that I used to download locally all the wheel and zip packages that are uploaded automatically by the CI bots to the Github Releases page https://github.com/anthrotype/brotli-wheels/releases/latest, and to upload these to the Python Package Index using the twine tool.
Let's live with this semi-automatic method of upload for now.

Fixes #5 