### PR TITLE
Build wheels for Python 3.12; disable PyPy wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
         os: [macos-latest, windows-latest]
         arch: [auto64]
         build: ["*"]
+        # temporarily disable building wheels for PyPy until this gets fixed:
+        # https://github.com/google/brotli-wheels/issues/19
+        skip: ["pp*"]
         include:
           # the manylinux1 docker images only contain from python3.6 to 3.9
           - os: ubuntu-latest
@@ -61,28 +64,30 @@ jobs:
             build: "cp{36,37,38,39}-*"
             CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
             CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          # the manylinux2010 image also contains python 3.10 and pypy3.7 and 3.8
+          # the manylinux2010 image also contains python 3.10
           - os: ubuntu-latest
             arch: auto
             type: manylinux2010
-            build: "pp{37,38}-* cp310-*"
+            build: "cp310-*"
             CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
             CIBW_MANYLINUX_I686_IMAGE: manylinux2010
-          # the manylinux2014 image also contains python 3.11 and pypy3.9
+          # the manylinux2014 image also contains python 3.11 and 3.12
           - os: ubuntu-latest
             arch: auto
             type: manylinux2014
-            build: "pp39-* cp311-*"
+            build: "cp311-* cp312-*"
             CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
             CIBW_MANYLINUX_I686_IMAGE: manylinux2014
 
           - os: macos-latest
             arch: universal2
             build: "*"
+            skip: "pp*"
 
           - os: windows-latest
             arch: auto32
             build: "*"
+            skip: "pp*"
     steps:
     - uses: actions/checkout@v2
       with:
@@ -97,6 +102,7 @@ jobs:
       run: python -m cibuildwheel --output-dir wheelhouse "${PACKAGE_DIR}"
       env:
         CIBW_BUILD: ${{ matrix.build }}
+        CIBW_SKIP: ${{ matrix.skip }}
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.CIBW_MANYLINUX_X86_64_IMAGE }}
         CIBW_ARCHS: ${{ matrix.arch }}
@@ -110,7 +116,7 @@ jobs:
     strategy:
       matrix:
         # aarch64 uses qemu so it's slow, build each py version in parallel jobs
-        python: [36, 37, 38, 39, 310, 311]
+        python: [36, 37, 38, 39, 310, 311, 312]
         arch: [aarch64, ppc64le]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes https://github.com/google/brotli-wheels/issues/18.

For PyPy see https://github.com/google/brotli-wheels/issues/19