### PR TITLE
[ci.yml] use Trusted Publishing for uploading packages to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,8 @@ jobs:
     needs: [build_wheels, build_arch_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
     - uses: actions/download-artifact@v4
@@ -142,6 +144,4 @@ jobs:
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}
         skip_existing: true


### PR DESCRIPTION
Once @eustas configures the trusted publisher on PyPI at https://pypi.org/manage/project/brotli/settings/publishing/, this should work

Reminder for PyPI setup:
- PyPI Project Name: brotli
- Owner: google
- Repository: brotli-wheels
- Workflow: ci.yml
- Environment: (leave blank)
