### PR TITLE
Add Windows ARM64 builds and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,30 +57,30 @@ jobs:
       matrix:
         # macos-13 runners are still x86_64, macos-14 (latest) are arm64; we want to build
         # the x86_64 wheel on/for x86_64 macs
-        os: [macos-13, windows-latest]
+        os: [macos-13, windows-latest, windows-11-arm]
         arch: [auto64]
-        build: ["cp{38,39,310,311,312,313,314}-*"]
+        build: ["cp{39,310,311,312,313,314}-*"]
         # temporarily disable building wheels for PyPy until this gets fixed:
         # https://github.com/google/brotli-wheels/issues/19
         # skip free-threaded Python builds until compatibility is verified
         skip: ["pp* cp*t-*"]
         include:
-          # manylinux2014 for python 3.8+ (broader compatibility)
+          # manylinux2014 for python 3.9+ (broader compatibility)
           - os: ubuntu-latest
             arch: auto
             type: manylinux2014
-            build: "cp{38,39,310,311,312,313,314}-*"
+            build: "cp{39,310,311,312,313,314}-*"
             CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
             CIBW_MANYLINUX_I686_IMAGE: manylinux2014
 
           - os: macos-latest
             arch: universal2
-            build: "cp{38,39,310,311,312,313,314}-*"
+            build: "cp{39,310,311,312,313,314}-*"
             skip: "pp* cp*t-*"
 
           - os: windows-latest
             arch: auto32
-            build: "cp{38,39,310,311,312,313,314}-*"
+            build: "cp{39,310,311,312,313,314}-*"
             skip: "pp* cp*t-*"
     steps:
     - uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
     strategy:
       matrix:
         # aarch64 uses qemu so it's slow, build each py version in parallel jobs
-        python: [38, 39, 310, 311, 312, 313, 314]
+        python: [39, 310, 311, 312, 313, 314]
         arch: [aarch64, ppc64le]
     steps:
     - uses: actions/checkout@v4
@@ -136,8 +136,8 @@ jobs:
         path: wheelhouse/*.whl
         name: wheels-${{ matrix.arch }}-${{ matrix.python }}
 
-  build_wheels_py36_37:
-    name: ${{ matrix.type }} ${{ matrix.arch }} on ${{ matrix.os }} (py36-37)
+  build_wheels_py36_37_38:
+    name: ${{ matrix.type }} ${{ matrix.arch }} on ${{ matrix.os }} (py36-38)
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -147,7 +147,7 @@ jobs:
       matrix:
         os: [macos-13, windows-latest]
         arch: [auto64]
-        build: ["cp{36,37}-*"]
+        build: ["cp{36,37,38}-*"]
         skip: ["pp*"]
         include:
           # manylinux2010 for python 3.6-3.7 (these versions not in manylinux2014)
@@ -158,9 +158,16 @@ jobs:
             CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
             CIBW_MANYLINUX_I686_IMAGE: manylinux2010
 
+          - os: ubuntu-latest
+            arch: auto
+            type: manylinux2014
+            build: "cp38-*"
+            CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+            CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+
           - os: windows-latest
             arch: auto32
-            build: "cp{36,37}-*"
+            build: "cp{36,37,38}-*"
             skip: "pp*"
     steps:
     - uses: actions/checkout@v4
@@ -185,14 +192,14 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
-        name: wheels-py36-37-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.type }}
+        name: wheels-py36-38-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.type }}
 
-  build_arch_wheels_py36_37:
-    name: py${{ matrix.python }} on ${{ matrix.arch }} (py36-37)
+  build_arch_wheels_py36_37_38:
+    name: py${{ matrix.python }} on ${{ matrix.arch }} (py36-38)
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [36, 37]
+        python: [36, 37, 38]
         arch: [aarch64, ppc64le]
     steps:
     - uses: actions/checkout@v4
@@ -213,7 +220,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
-        name: wheels-py36-37-${{ matrix.arch }}-${{ matrix.python }}
+        name: wheels-py36-38-${{ matrix.arch }}-${{ matrix.python }}
 
   build_wheels_py27:
     name: ${{ matrix.type }} ${{ matrix.arch }} on ${{ matrix.os }} (py27)
@@ -431,7 +438,7 @@ jobs:
 
   deploy:
     name: Upload if release
-    needs: [build_wheels, build_arch_wheels, build_wheels_py36_37, build_arch_wheels_py36_37, build_wheels_py27, build_wheels_py27_windows, build_sdist]
+    needs: [build_wheels, build_arch_wheels, build_wheels_py36_37_38, build_arch_wheels_py36_37_38, build_wheels_py27, build_wheels_py27_windows, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
       run:
         working-directory: ${{ env.PACKAGE_DIR }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: true
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.x"
     # PEP 625 requires normalized (lowercase) package names in wheel metadata.
@@ -41,7 +41,7 @@ jobs:
       run: python setup.py sdist
     - name: Check metadata
       run: twine check dist/*.tar.gz
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         path: ${{ env.PACKAGE_DIR }}/dist/*.tar.gz
         name: sdist
@@ -83,11 +83,11 @@ jobs:
             build: "cp{39,310,311,312,313,314}-*"
             skip: "pp* cp*t-*"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.x"
     - name: Patch setup.py to use normalized package name
@@ -102,7 +102,7 @@ jobs:
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.CIBW_MANYLINUX_X86_64_IMAGE }}
         CIBW_ARCHS: ${{ matrix.arch }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         path: wheelhouse/*.whl
         name: wheels-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.type }}
@@ -116,7 +116,7 @@ jobs:
         python: [39, 310, 311, 312, 313, 314]
         arch: [aarch64, ppc64le]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: true
     - uses: docker/setup-qemu-action@v3
@@ -131,7 +131,7 @@ jobs:
       env:
         CIBW_BUILD: cp${{ matrix.python }}-*
         CIBW_ARCHS: ${{ matrix.arch }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         path: wheelhouse/*.whl
         name: wheels-${{ matrix.arch }}-${{ matrix.python }}
@@ -170,11 +170,11 @@ jobs:
             build: "cp{36,37,38}-*"
             skip: "pp*"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.x"
     - name: Patch setup.py to use normalized package name
@@ -189,7 +189,7 @@ jobs:
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.CIBW_MANYLINUX_X86_64_IMAGE }}
         CIBW_ARCHS: ${{ matrix.arch }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         path: wheelhouse/*.whl
         name: wheels-py36-38-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.type }}
@@ -202,7 +202,7 @@ jobs:
         python: [36, 37, 38]
         arch: [aarch64, ppc64le]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: true
     - uses: docker/setup-qemu-action@v3
@@ -217,7 +217,7 @@ jobs:
       env:
         CIBW_BUILD: cp${{ matrix.python }}-*
         CIBW_ARCHS: ${{ matrix.arch }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         path: wheelhouse/*.whl
         name: wheels-py36-38-${{ matrix.arch }}-${{ matrix.python }}
@@ -248,12 +248,12 @@ jobs:
             CIBW_MANYLINUX_X86_64_IMAGE: ""
             CIBW_MANYLINUX_I686_IMAGE: ""
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.x"
 
@@ -276,7 +276,7 @@ jobs:
         # Enable C99 for Python 2.7 (brotli requires it)
         CIBW_ENVIRONMENT: "CFLAGS='-std=c99'"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         path: wheelhouse/*.whl
         name: wheels-py27-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.type }}
@@ -293,12 +293,12 @@ jobs:
           - arch: x86
             python_arch: x86
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.x"
 
@@ -431,7 +431,7 @@ jobs:
         python -m pip install wheelhouse\*.whl
         python -m unittest discover -v -s ${{ env.PACKAGE_DIR }}\python\ -p "*_test.py"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         path: wheelhouse/*.whl
         name: wheels-py27-windows-${{ matrix.arch }}
@@ -443,7 +443,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         path: dist
         merge-multiple: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 runners are still x86_64, macos-14 (latest) are arm64; we want to build
+        # macos-15-intel runners are x86_64, macos-latest are arm64; we want to build
         # the x86_64 wheel on/for x86_64 macs
-        os: [macos-13, windows-latest, windows-11-arm]
+        os: [macos-15-intel, windows-latest, windows-11-arm]
         arch: [auto64]
         build: ["cp{39,310,311,312,313,314}-*"]
         # temporarily disable building wheels for PyPy until this gets fixed:
@@ -145,7 +145,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, windows-latest]
+        os: [macos-15-intel, windows-latest]
         arch: [auto64]
         build: ["cp{36,37,38}-*"]
         skip: ["pp*"]
@@ -241,7 +241,7 @@ jobs:
             CIBW_MANYLINUX_I686_IMAGE: manylinux1
 
           # macOS x86_64
-          - os: macos-13
+          - os: macos-15-intel
             arch: auto64
             build: "cp27-*"
             type: macos

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository is used to build and publish brotli "[wheels](https://pythonwhee
 ![CI Status](https://github.com/google/brotli-wheels/actions/workflows/ci.yml/badge.svg)
 
 ## What are wheels?
-Wheels are the new standard of Python distribution and are intended to replace eggs. 
+Wheels are the new standard of Python distribution and are intended to replace eggs.
 
 ## Advantages of wheels
  - Faster installation for pure Python and native C extension packages.
@@ -37,10 +37,10 @@ git push
 ```
 
 This will automatically trigger GitHub Actions to build wheels for:
-- **Python versions**: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+- **Python versions**: 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 (plus legacy 2.7 and 3.6-3.8 wheels)
 - **Linux**: x86_64, i686, aarch64, ppc64le (manylinux2014)
 - **macOS**: x86_64, ARM64 (universal2)
-- **Windows**: x64, x86
+- **Windows**: x64, x86, ARM64
 
 ### 3. Publish to PyPI (for releases)
 


### PR DESCRIPTION
I primarily wanted to add Windows ARM64 builds, but there were a few additional changes that needed to be made to get the CI to run:
- cibuildwheel dropped cp38 support in v4.0.0, so the cp38 jobs had to be moved to the 'legacy' builds.
- The `macos-13` runner isn't available anymore, so I updated those jobs to use `macos-15-intel`.
- I also updated some of the actions (actions/checkout@v4, actions/setup-python@v5, actions/upload-artifact@v4) that were using the now-deprecated Node.js 20.